### PR TITLE
Mudar nome da organização na licença 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Jovens-Gafanhotos
+Copyright (c) 2022 Catsuc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
O nome da organização estava incorreto. 